### PR TITLE
Fix application buttons and add promotion log buttons

### DIFF
--- a/cogs/applications.py
+++ b/cogs/applications.py
@@ -62,18 +62,35 @@ class AdminDeclineButton(discord.ui.Button):
         await original_message.edit(embed=new_embed, view=None)
         await interaction.response.send_message("Заявка успешно отклонена.", ephemeral=True)
 
-async def send_application(interaction: discord.Interaction, channel_id: int, roles_ids: list[int], embed: discord.Embed, app_type: str):
+class ApplicationAdminView(discord.ui.View):
+    def __init__(self, required_roles: list[int], app_type: str):
+        super().__init__(timeout=None)
+        self.add_item(AdminAcceptButton(required_roles, app_type=app_type))
+        self.add_item(AdminDeclineButton(required_roles))
+
+
+async def send_application(
+    interaction: discord.Interaction,
+    channel_id: int,
+    roles_ids: list[int],
+    embed: discord.Embed,
+    app_type: str,
+):
     channel = interaction.guild.get_channel(channel_id)
     if not channel:
         await interaction.response.send_message("Ошибка: Канал для заявок не найден.", ephemeral=True, delete_after=10)
         return
+
     ping_message = " ".join([f"<@&{role_id}>" for role_id in roles_ids])
     header_text = f"{ping_message} новая заявка ({app_type})! {interaction.user.mention}"
-    admin_view = discord.ui.View()
-    admin_view.add_item(AdminAcceptButton(roles_ids, app_type=app_type))
-    admin_view.add_item(AdminDeclineButton(roles_ids))
+
+    admin_view = ApplicationAdminView(roles_ids, app_type)
     await channel.send(content=header_text, embed=embed, view=admin_view)
-    await interaction.response.send_message(f"✅ Ваша заявка на {app_type} успешно отправлена!", ephemeral=True)
+    interaction.client.add_view(admin_view)
+
+    await interaction.response.send_message(
+        f"✅ Ваша заявка на {app_type} успешно отправлена!", ephemeral=True
+    )
 
 class ApplicationView(discord.ui.View):
     def __init__(self):

--- a/cogs/promotions.py
+++ b/cogs/promotions.py
@@ -34,6 +34,19 @@ class PromotionModal(discord.ui.Modal, title="Отчет о повышении")
         await interaction.response.send_message("✅ Ваш отчет на повышение успешно отправлен.", ephemeral=True)
 
 
+class PromotionLogView(discord.ui.View):
+    def __init__(self):
+        super().__init__(timeout=None)
+
+    @discord.ui.button(emoji="✅", style=discord.ButtonStyle.success, custom_id="promo_log_check")
+    async def log_check(self, interaction: discord.Interaction, button: discord.ui.Button):
+        await interaction.response.send_message("Отмечено.", ephemeral=True)
+
+    @discord.ui.button(label="После нулей", style=discord.ButtonStyle.secondary, custom_id="promo_log_after")
+    async def log_after(self, interaction: discord.Interaction, button: discord.ui.Button):
+        await interaction.response.send_message("Отмечено.", ephemeral=True)
+
+
 class PromotionActionView(discord.ui.View):
     def __init__(self, reviewer_role_id: int):
         super().__init__(timeout=None)
@@ -62,15 +75,15 @@ class PromotionActionView(discord.ui.View):
                 applicant_mention = f"<@{applicant_id}>"
                 rank_to = original_embed.fields[2].value
                 log_role_mention = f"<@&{config.PROMOTION_LOG_ROLE_ID}>"
-                
-                
+
                 log_message = (
                     f"{log_role_mention}\n"
                     f"{interaction.user.mention} **одобрил отчет** {applicant_mention} на **{rank_to} ранг.**\n"
-                    f"{interaction.message.jump_url}\n" 
-                    f"После отправки КА оставьте реакцию ✅"
+                    f"{interaction.message.jump_url}\n"
                 )
-                await log_channel.send(log_message)
+                log_view = PromotionLogView()
+                await log_channel.send(log_message, view=log_view)
+                interaction.client.add_view(log_view)
         else:
             new_embed.color = discord.Color.red()
             new_embed.set_field_at(5, name="Статус", value=f"Отклонено: {interaction.user.mention}", inline=False)
@@ -121,4 +134,5 @@ class PromotionsCog(commands.Cog):
 async def setup(bot: commands.Bot):
     bot.add_view(PromotionPanelView(0, 0))
     bot.add_view(PromotionActionView(0))
+    bot.add_view(PromotionLogView())
     await bot.add_cog(PromotionsCog(bot))


### PR DESCRIPTION
## Summary
- Keep admin application views alive to avoid interaction errors
- Replace promotion log reactions with buttons for quick responses

## Testing
- `python -m py_compile cogs/applications.py cogs/promotions.py`


------
https://chatgpt.com/codex/tasks/task_e_68b5cb51b15483298eb559eba832de22