### PR TITLE
Limit lifetime of temporary Discord views

### DIFF
--- a/cogs/applications.py
+++ b/cogs/applications.py
@@ -7,9 +7,12 @@ import config
 
 class SetRankModal(discord.ui.Modal, title="Назначение ранга"):
     rank_input = discord.ui.TextInput(label="На какой ранг назначить?", placeholder="Например: 5", required=True)
-    def __init__(self, original_message: discord.Message):
+
+    def __init__(self, original_message: discord.Message, admin_view: discord.ui.View):
         super().__init__()
         self.original_message = original_message
+        self.admin_view = admin_view
+
     async def on_submit(self, interaction: discord.Interaction):
         original_embed = self.original_message.embeds[0]
         new_embed = original_embed.copy()
@@ -18,6 +21,7 @@ class SetRankModal(discord.ui.Modal, title="Назначение ранга"):
         status_text = f"Принял: {interaction.user.mention}\nНазначен ранг: **{self.rank_input.value}**"
         new_embed.add_field(name="Статус", value=status_text, inline=False)
         await self.original_message.edit(embed=new_embed, view=None)
+        self.admin_view.stop()
         await interaction.response.send_message("Заявка успешно одобрена, ранг назначен.", ephemeral=True)
 
 class AdminAcceptButton(discord.ui.Button):
@@ -31,7 +35,7 @@ class AdminAcceptButton(discord.ui.Button):
             await interaction.response.send_message("У вас нет прав для выполнения этого действия.", ephemeral=True)
             return
         if self.app_type in ["восстановление", "перевод"]:
-            await interaction.response.send_modal(SetRankModal(original_message=interaction.message))
+            await interaction.response.send_modal(SetRankModal(original_message=interaction.message, admin_view=self.view))
         else:
             original_message = interaction.message
             original_embed = original_message.embeds[0]
@@ -41,6 +45,7 @@ class AdminAcceptButton(discord.ui.Button):
             status_text = f"Принял: {interaction.user.mention}"
             new_embed.add_field(name="Статус", value=status_text, inline=False)
             await original_message.edit(embed=new_embed, view=None)
+            self.view.stop()
             await interaction.response.send_message("Заявка на вступление успешно одобрена.", ephemeral=True)
 
 class AdminDeclineButton(discord.ui.Button):
@@ -60,11 +65,12 @@ class AdminDeclineButton(discord.ui.Button):
         status_text = f"Отклонил: {interaction.user.mention}"
         new_embed.add_field(name="Статус", value=status_text, inline=False)
         await original_message.edit(embed=new_embed, view=None)
+        self.view.stop()
         await interaction.response.send_message("Заявка успешно отклонена.", ephemeral=True)
 
 class ApplicationAdminView(discord.ui.View):
     def __init__(self, required_roles: list[int], app_type: str):
-        super().__init__(timeout=None)
+        super().__init__(timeout=86400)
         self.add_item(AdminAcceptButton(required_roles, app_type=app_type))
         self.add_item(AdminDeclineButton(required_roles))
 
@@ -86,7 +92,6 @@ async def send_application(
 
     admin_view = ApplicationAdminView(roles_ids, app_type)
     await channel.send(content=header_text, embed=embed, view=admin_view)
-    interaction.client.add_view(admin_view)
 
     await interaction.response.send_message(
         f"✅ Ваша заявка на {app_type} успешно отправлена!", ephemeral=True

--- a/cogs/crime_reports.py
+++ b/cogs/crime_reports.py
@@ -80,10 +80,11 @@ class ReviewCompleteButton(discord.ui.Button):
         new_embed.add_field(name="Итог", value=f"Рассмотрел: {interaction.user.mention}", inline=False)
         self.disabled = True
         await interaction.message.edit(embed=new_embed, view=view)
+        view.stop()
         await interaction.response.send_message("Заявление отмечено как рассмотренное.", ephemeral=True)
 class ReportActionView(discord.ui.View):
     def __init__(self):
-        super().__init__(timeout=None)
+        super().__init__(timeout=86400)
         self.add_item(TakeReportButton())
 class ReportPanelView(discord.ui.View):
     def __init__(self):
@@ -134,5 +135,4 @@ class CrimeReportCog(commands.Cog):
 
 async def setup(bot: commands.Bot):
     bot.add_view(ReportPanelView())
-    bot.add_view(ReportActionView())
     await bot.add_cog(CrimeReportCog(bot))

--- a/cogs/promotions.py
+++ b/cogs/promotions.py
@@ -36,20 +36,22 @@ class PromotionModal(discord.ui.Modal, title="Отчет о повышении")
 
 class PromotionLogView(discord.ui.View):
     def __init__(self):
-        super().__init__(timeout=None)
+        super().__init__(timeout=86400)
 
     @discord.ui.button(emoji="✅", style=discord.ButtonStyle.success, custom_id="promo_log_check")
     async def log_check(self, interaction: discord.Interaction, button: discord.ui.Button):
         await interaction.response.send_message("Отмечено.", ephemeral=True)
+        self.stop()
 
     @discord.ui.button(label="После нулей", style=discord.ButtonStyle.secondary, custom_id="promo_log_after")
     async def log_after(self, interaction: discord.Interaction, button: discord.ui.Button):
         await interaction.response.send_message("Отмечено.", ephemeral=True)
+        self.stop()
 
 
 class PromotionActionView(discord.ui.View):
     def __init__(self, reviewer_role_id: int):
-        super().__init__(timeout=None)
+        super().__init__(timeout=86400)
         self.children[0].custom_id = f"promo_accept:{reviewer_role_id}"
         self.children[1].custom_id = f"promo_decline:{reviewer_role_id}"
 
@@ -83,12 +85,12 @@ class PromotionActionView(discord.ui.View):
                 )
                 log_view = PromotionLogView()
                 await log_channel.send(log_message, view=log_view)
-                interaction.client.add_view(log_view)
         else:
             new_embed.color = discord.Color.red()
             new_embed.set_field_at(5, name="Статус", value=f"Отклонено: {interaction.user.mention}", inline=False)
 
         await interaction.message.edit(embed=new_embed, view=self)
+        self.stop()
 
     @discord.ui.button(label="Принять", style=discord.ButtonStyle.success)
     async def accept(self, interaction: discord.Interaction, button: discord.ui.Button):
@@ -133,6 +135,4 @@ class PromotionsCog(commands.Cog):
 
 async def setup(bot: commands.Bot):
     bot.add_view(PromotionPanelView(0, 0))
-    bot.add_view(PromotionActionView(0))
-    bot.add_view(PromotionLogView())
     await bot.add_cog(PromotionsCog(bot))

--- a/cogs/questions.py
+++ b/cogs/questions.py
@@ -25,7 +25,7 @@ class QuestionModal(discord.ui.Modal, title="Задайте свой вопро�
 
 class QuestionActionView(discord.ui.View):
     def __init__(self):
-        super().__init__(timeout=None)
+        super().__init__(timeout=86400)
     @discord.ui.button(label="Вопрос решён", style=discord.ButtonStyle.success, custom_id="resolve_question_button")
     async def resolve_question(self, interaction: discord.Interaction, button: discord.ui.Button):
         user_roles_ids = [role.id for role in interaction.user.roles]
@@ -50,6 +50,7 @@ class QuestionActionView(discord.ui.View):
         new_embed.add_field(name="Статус", value=f"Вопрос решил: {interaction.user.mention}", inline=False)
         button.disabled = True
         await interaction.message.edit(embed=new_embed, view=self)
+        self.stop()
         await interaction.response.send_message("Вопрос отмечен как решённый.", ephemeral=True)
 
 class QuestionPanelView(discord.ui.View):
@@ -101,5 +102,4 @@ class QuestionCog(commands.Cog):
 # Функция для регистрации кога и постоянных кнопок
 async def setup(bot: commands.Bot):
     bot.add_view(QuestionPanelView())
-    bot.add_view(QuestionActionView())
     await bot.add_cog(QuestionCog(bot))

--- a/cogs/special_equipment.py
+++ b/cogs/special_equipment.py
@@ -94,7 +94,7 @@ class LossModal(discord.ui.Modal, title="Утеря спец. вооружени
 # =================================================================
 class RequestActionView(discord.ui.View):
     def __init__(self):
-        super().__init__(timeout=None)
+        super().__init__(timeout=86400)
 
     async def check_staff_perms(self, interaction: discord.Interaction) -> bool:
         user_roles_ids = [role.id for role in interaction.user.roles]
@@ -113,6 +113,7 @@ class RequestActionView(discord.ui.View):
 
         for item in self.children: item.disabled = True
         await interaction.message.edit(embed=new_embed, view=self)
+        self.stop()
         await interaction.response.send_message("Запрос одобрен.", ephemeral=True)
     
     @discord.ui.button(label="Отклонить", style=discord.ButtonStyle.danger, custom_id="decline_gear_request")
@@ -126,6 +127,7 @@ class RequestActionView(discord.ui.View):
 
         for item in self.children: item.disabled = True
         await interaction.message.edit(embed=new_embed, view=self)
+        self.stop()
         await interaction.response.send_message("Запрос отклонен.", ephemeral=True)
 
 
@@ -182,5 +184,4 @@ class SpecialEquipmentCog(commands.Cog):
 
 async def setup(bot: commands.Bot):
     bot.add_view(SpecialEquipmentPanelView())
-    bot.add_view(RequestActionView())
     await bot.add_cog(SpecialEquipmentCog(bot))

--- a/cogs/transfers.py
+++ b/cogs/transfers.py
@@ -86,16 +86,18 @@ class ConfirmView(discord.ui.View):
 
         await channel.send(content=header, embed=embed, view=TransferActionView())
         await interaction.edit_original_response(content="✅ Ваш перевод успешно отправлен на рассмотрение!", view=None)
+        self.stop()
     @discord.ui.button(label="Отмена", style=discord.ButtonStyle.danger)
     async def cancel(self, interaction: discord.Interaction, button: discord.ui.Button):
         await interaction.response.edit_message(content="Перевод отменен.", view=None)
+        self.stop()
 
 # =================================================================
 # ШАГ 5: СИСТЕМА ОДОБРЕНИЯ
 # =================================================================
 class TransferActionView(discord.ui.View):
     def __init__(self):
-        super().__init__(timeout=None)
+        super().__init__(timeout=86400)
         self.approvers = set()
     def get_dept_data_from_embed(self, embed: discord.Embed):
         old_dept_name = embed.fields[2].value; new_dept_name = embed.fields[3].value
@@ -145,6 +147,7 @@ class TransferActionView(discord.ui.View):
         new_embed.set_field_at(5, name="Статус", value=f"Перевод отклонен {interaction.user.mention}.", inline=False)
         for item in self.children: item.disabled = True
         await interaction.message.edit(embed=new_embed, view=self)
+        self.stop()
 
 class IssueRolesButton(discord.ui.Button):
     def __init__(self):
@@ -198,6 +201,7 @@ class IssueRolesButton(discord.ui.Button):
         new_embed.set_field_at(5, name="Статус", value=f"Перевод завершен. Роли и ник обновлены {interaction.user.mention}.", inline=False)
         self.disabled = True
         await interaction.message.edit(embed=new_embed, view=self.view)
+        self.view.stop()
 
 # =================================================================
 # ШАГ 1: ГЛАВНАЯ ПАНЕЛЬ
@@ -233,5 +237,4 @@ class TransfersCog(commands.Cog):
 
 async def setup(bot: commands.Bot):
     bot.add_view(TransferPanelView())
-    bot.add_view(TransferActionView())
     await bot.add_cog(TransfersCog(bot))


### PR DESCRIPTION
## Summary
- stop registering per-message moderation views globally and give them a 24h timeout
- stop or remove views when messages are edited so one-off buttons don't pile up
- keep persistent panels registered on startup only

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68c3362065ac8329a945f2916568dfaf